### PR TITLE
Fixes two issues. 

### DIFF
--- a/django_vueformgenerator/components.py
+++ b/django_vueformgenerator/components.py
@@ -131,3 +131,8 @@ class SelectComponent(six.with_metaclass(DeclarativeFieldsMetaclass, BaseCompone
 
     type = Literal('select')
     values = Attr('choices', type=get_values)
+
+
+@register_schema_for(widgets.SelectMultiple)
+class MultipleSelectComponent(SelectComponent):
+    multiple = Literal(True)

--- a/django_vueformgenerator/schema.py
+++ b/django_vueformgenerator/schema.py
@@ -30,9 +30,13 @@ class Schema(object):
             field.__name__ = name
 
         fields = []
-        for field in form.fields.values():
-            component = registry.lookup(field)
-            fields.append(component.render(field))
+        for field_name in form.fields.keys():
+            field = form[field_name]
+            component = registry.lookup(field.field)
+            rendered = component.render(field.field)
+            if not rendered['label']:
+                rendered['label'] = field.label
+            fields.append(rendered)
 
         model = tree()
         for schema_field in fields:

--- a/django_vueformgenerator/schema.py
+++ b/django_vueformgenerator/schema.py
@@ -43,8 +43,10 @@ class Schema(object):
             value = None
             if initial is not None:
                 value = initial
-            if data is not None:
+            if form.is_bound and data is not None:
                 value = data
+
+            value = form[key].field.prepare_value(value)
 
             m = prev = model
             for k in schema_field['model'].split('.'):


### PR DESCRIPTION
The model is now run through prepare_value on each field. This keeps most fields the same but converts modelchoicefields to primary keys. It converts some other fields like duration fields and UUID fields to objects that can be serialized. 

The field's data property is only taken if the form is bound. I found that it was populated on BooleanFields even if the form wasn't bound overriding the initial value.

Fixes #1